### PR TITLE
feature/enable-hashing-override

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,13 +59,16 @@ Publish the package config file:
 
 Optionally set a `HASH_MODEL_IDS_SALT` in `.env`.
 
-
 ## Translations
 
 Publish the package translations file:
 
 `php artisan vendor:publish --tag=hash-model-ids-lang`
 
+
+## Development
+
+Sometimes, during development, it can be awkward dealing with hashed ids. Set `HASH_MODEL_IDS_OVERRIDE=true` in your environment file to override the hashing instance to use the actual id of a model instead.
 
 ## Testing
 

--- a/config/hash-model-ids.php
+++ b/config/hash-model-ids.php
@@ -3,5 +3,6 @@
 return [
     'salt' => env('HASH_MODEL_IDS_SALT', hash('sha256', env('APP_KEY'))),
     'min_hash_length' => 10,
-    'alphabet' => 'abcdefghijklmnopqrstuvwxyz0123456789'
+    'alphabet' => 'abcdefghijklmnopqrstuvwxyz0123456789',
+    'override' => (bool) env('HASH_MODEL_IDS_OVERRIDE', false),
 ];

--- a/src/ModelIdHasherOverride.php
+++ b/src/ModelIdHasherOverride.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Netsells\HashModelIds;
+
+use Illuminate\Database\Eloquent\Model;
+
+class ModelIdHasherOverride implements ModelIdHasherInterface
+{
+    public function encode(Model $model, $id): string
+    {
+        return (string) $id;
+    }
+
+    public function decode(Model $model, $hash): string
+    {
+        return (string) $hash;
+    }
+}

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace Netsells\HashModelIds;
 
+use Illuminate\Foundation\Application;
 use Illuminate\Support\ServiceProvider as BaseServiceProvider;
 
 class ServiceProvider extends BaseServiceProvider
@@ -19,12 +20,19 @@ class ServiceProvider extends BaseServiceProvider
         );
 
         $this->app->singleton(ModelIdHasherInterface::class, function ($app) {
-            return new ModelIdHasher([
-                'salt' => config('hash-model-ids.salt'),
-                'min_hash_length' => config('hash-model-ids.min_hash_length'),
-                'alphabet' => config('hash-model-ids.alphabet'),
-            ]);
+            return $this->shouldOverrideHasher($app)
+                ? new ModelIdHasherOverride()
+                : new ModelIdHasher([
+                    'salt' => config('hash-model-ids.salt'),
+                    'min_hash_length' => config('hash-model-ids.min_hash_length'),
+                    'alphabet' => config('hash-model-ids.alphabet'),
+                ]);
         });
+    }
+
+    private function shouldOverrideHasher(Application $app): bool
+    {
+        return ! $app->isProduction() && config('hash-model-ids.override', false);
     }
 
     /**

--- a/tests/Integration/AbstractIntegrationTest.php
+++ b/tests/Integration/AbstractIntegrationTest.php
@@ -19,6 +19,6 @@ abstract class AbstractIntegrationTest extends TestCase
 
     protected function defineEnvironment($app): void
     {
-        $app['config']->set('hash_model_ids.salt', 'test-salt');
+        $app['config']->set('hash-model-ids.salt', 'test-salt');
     }
 }

--- a/tests/Integration/HasherOverrideTest.php
+++ b/tests/Integration/HasherOverrideTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Netsells\HashModelIds\Tests\Integration;
+
+use Netsells\HashModelIds\Tests\Integration\fixtures\Models\Foo;
+
+class HasherOverrideTest extends AbstractIntegrationTest
+{
+    private Foo $foo;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->foo = Foo::create();
+    }
+
+    protected function defineEnvironment($app): void
+    {
+        parent::defineEnvironment($app);
+
+        $app['config']->set('hash-model-ids.override', true);
+    }
+
+    public function testHashedIdAttributeReturnsActualId(): void
+    {
+        $this->assertNotNull($this->foo->getKey());
+        $this->assertEquals($this->foo->getKey(), $this->foo->hashed_id);
+    }
+
+    public function testScopeWhereHashedId(): void
+    {
+        $hash = $this->foo->getKey();
+
+        $foo = Foo::whereHashedId($hash)->first();
+
+        $this->assertTrue($foo->is($this->foo));
+    }
+}


### PR DESCRIPTION
## Overview
- [x] I have performed a self review of my code
- [x] I have made corresponding changes to the documentation
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added sufficient logging
<!-- Remove the below if this project doesn't have tests (maybe it should?) -->
- [x] New and existing tests pass locally with my changes
- [x] The code modified as part of this PR has been covered with tests
<!-- Remove the below if this project doesn't include an API -->
- [ ] The API spec has been modified inline with the changes in this PR

### Problem statement
Sometimes, during development, it can be awkward dealing with hashed ids.

### Solution
This PR adds configuration that can read a `HASH_MODEL_IDS_OVERRIDE` environment variable, which can override the hashing instance to just use the actual id of a model.

### Dependencies
n/a

### Test procedures
n/a

### Links
n/a

## Deployment

### Migrations
No

### Environment variables
`HASH_MODEL_IDS_OVERRIDE`

### Deployment notes
n/a
