### PR TITLE
feat: add whereNotHashedIds scope

### DIFF
--- a/tests/Integration/HashedModelIdTest.php
+++ b/tests/Integration/HashedModelIdTest.php
@@ -38,4 +38,16 @@ class HashedModelIdTest extends AbstractIntegrationTestCase
 
         $this->assertCount(2, $foos);
     }
+
+    public function testScopeWhereNotHashedIds(): void
+    {
+        $hash = $this->foo->hashed_id;
+        $hash2 = Foo::create()->hashed_id;
+
+        $foos = Foo::whereNotHashedIds([$hash])->get();
+
+        $this->assertCount(1, $foos);
+
+        $this->assertSame($hash2, $foos->first()->hashed_id);
+    }
 }


### PR DESCRIPTION
## Overview
- [x] I have performed a self review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added sufficient logging
- [x] New and existing tests pass locally with my changes
- [x] The code modified as part of this PR has been covered with tests

### Problem statement
This package has a scope called `whereHashedIds` which allows us to get all models where the ids match the hashed ids. However, there are times where we need to get all records where the hashed id is not in the array.

### Solution
This PR adds a new `whereNotHashedIds` scope.
