### PR TITLE
Add support for Laravel 11

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -11,8 +11,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['8.1', '8.2']
-        laravel: ['^9.1', '^10.0']
+        php: ['8.2', '8.3']
+        laravel: ['^10.0', '^11.0']
 
     steps:
       - name: Checkout the repo

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,6 @@
     "require": {
         "php": "^8.2",
         "hashids/hashids": "^5.0",
-        "illuminate/translation": "^10.0|^11.0",
         "illuminate/support": "^10.0|^11.0",
         "illuminate/validation": "^10.0|^11.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -22,12 +22,14 @@
         }
     ],
     "require": {
-        "php": "^8.1",
-        "hashids/hashids": "^4.1",
-        "laravel/framework": "^9.1 || ^10.0"
+        "php": "^8.2",
+        "hashids/hashids": "^5.0",
+        "illuminate/translation": "^10.0|^11.0",
+        "illuminate/support": "^10.0|^11.0",
+        "illuminate/validation": "^10.0|^11.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^7.1 || ^8.0"
+        "orchestra/testbench": "^8.0|^9.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,8 @@
     "require": {
         "php": "^8.2",
         "hashids/hashids": "^5.0",
+        "illuminate/contracts": "^10.0|^11.0",
+        "illuminate/database": "^10.0|^11.0",
         "illuminate/support": "^10.0|^11.0",
         "illuminate/validation": "^10.0|^11.0"
     },

--- a/src/ExistsWithHashedIdRule.php
+++ b/src/ExistsWithHashedIdRule.php
@@ -3,7 +3,6 @@
 namespace Netsells\HashModelIds;
 
 use Closure;
-use Illuminate\Contracts\Validation\Rule;
 use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;

--- a/tests/Integration/ExistsWithHashedIdRuleTest.php
+++ b/tests/Integration/ExistsWithHashedIdRuleTest.php
@@ -3,6 +3,9 @@
 namespace Netsells\HashModelIds\Tests\Integration;
 
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Translation\Translator;
+use Illuminate\Validation\InvokableValidationRule;
+use Illuminate\Validation\Validator;
 use InvalidArgumentException;
 use Netsells\HashModelIds\ExistsWithHashedIdRule;
 use Netsells\HashModelIds\Tests\Integration\Fixtures\Models;
@@ -25,7 +28,9 @@ class ExistsWithHashedIdRuleTest extends AbstractIntegrationTestCase
 
     public function testRuleHandlesExpectedValueTypes(): void
     {
-        $rule = new ExistsWithHashedIdRule(Models\Foo::class);
+        $rule = InvokableValidationRule::make(
+            invokable: new ExistsWithHashedIdRule(Models\Foo::class),
+        )->setValidator(validator: $this->getValidator());
 
         $this->assertFalse($rule->passes(null, null));
         $this->assertFalse($rule->passes(null, []));
@@ -36,7 +41,9 @@ class ExistsWithHashedIdRuleTest extends AbstractIntegrationTestCase
     {
         $foo = Models\Foo::create();
 
-        $rule = new ExistsWithHashedIdRule(Models\Foo::class);
+        $rule = InvokableValidationRule::make(
+            invokable: new ExistsWithHashedIdRule(Models\Foo::class),
+        )->setValidator(validator: $this->getValidator());
 
         $this->assertTrue($rule->passes(null, $foo->hashed_id));
     }
@@ -45,7 +52,9 @@ class ExistsWithHashedIdRuleTest extends AbstractIntegrationTestCase
     {
         $foo = Models\Foo::create();
 
-        $rule = new ExistsWithHashedIdRule(Models\Foo::class);
+        $rule = InvokableValidationRule::make(
+            invokable: new ExistsWithHashedIdRule(Models\Foo::class),
+        )->setValidator(validator: $this->getValidator());
 
         $this->assertFalse($rule->passes(null, $foo->id));
     }
@@ -54,25 +63,32 @@ class ExistsWithHashedIdRuleTest extends AbstractIntegrationTestCase
     {
         $foo = Models\Foo::create([]);
 
-        $rule = new ExistsWithHashedIdRule(Models\Foo::class);
-
-        $this->assertFalse(
-            $rule
+        $rule = InvokableValidationRule::make(
+            invokable: (new ExistsWithHashedIdRule(Models\Foo::class))
                 ->where(function (Builder $query) use ($foo) {
                     $query->whereId($foo->hashed_id);
-                })
-                ->passes(null, $foo->hashed_id)
-        );
+                }),
+        )->setValidator(validator: $this->getValidator());
 
-        $rule = new ExistsWithHashedIdRule(Models\Foo::class);
+        $this->assertFalse($rule->passes(null, $foo->hashed_id));
 
-        $this->assertTrue(
-            $rule
+        $rule = InvokableValidationRule::make(
+            invokable: (new ExistsWithHashedIdRule(Models\Foo::class))
                 ->where(function (Builder $query) use ($foo) {
                     $query->whereId($foo->id);
                 })
-                ->whereNotNull('created_at')
-                ->passes(null, $foo->hashed_id)
+                ->whereNotNull('created_at'),
+        )->setValidator(validator: $this->getValidator());
+
+        $this->assertTrue($rule->passes(null, $foo->hashed_id));
+    }
+
+    private function getValidator(): Validator
+    {
+        return new Validator(
+            translator: $this->app->make(abstract: Translator::class),
+            data: [],
+            rules: [],
         );
     }
 }

--- a/tests/Unit/ModelIdHasherTest.php
+++ b/tests/Unit/ModelIdHasherTest.php
@@ -2,7 +2,6 @@
 
 namespace Netsells\HashModelIds\Tests\Unit;
 
-use Illuminate\Database\Eloquent\Model;
 use InvalidArgumentException;
 use Netsells\HashModelIds\ModelIdHasher;
 use Netsells\HashModelIds\Tests\Unit\Fixtures\Models;
@@ -27,8 +26,7 @@ class ModelIdHasherTest extends TestCase
     {
         $idHasher = $this->getNewModelIdHasher();
 
-        /** @var Model|MockObject $model */
-        $model = $this->getMockForAbstractClass(Model::class);
+        $model = new Models\Foo();
 
         $hash = $idHasher->encode($model, 1);
 
@@ -39,11 +37,11 @@ class ModelIdHasherTest extends TestCase
     {
         $idHasher = $this->getNewModelIdHasher();
 
-        /** @var Model|MockObject $foo */
-        $foo = $this->getMockForAbstractClass(Models\Foo::class);
+        /** @var \Illuminate\Database\Eloquent\Model|\PHPUnit\Framework\MockObject\MockObject $foo */
+        $foo = $this->createMock(Models\Foo::class);
 
-        /** @var Model|MockObject $bar */
-        $bar = $this->getMockForAbstractClass(Models\Bar::class);
+        /** @var \Illuminate\Database\Eloquent\Model|\PHPUnit\Framework\MockObject\MockObject $bar */
+        $bar = $this->createMock(Models\Bar::class);
 
         $this->assertNotSame($idHasher->encode($foo, 1), $idHasher->encode($bar, 1));
     }


### PR DESCRIPTION
## Overview
- [x] I have performed a self review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added sufficient logging
- [x] New and existing tests pass locally with my changes
- [x] The code modified as part of this PR has been covered with tests

### Summary
Laravel 11 was released yesterday and therefore we need to update our internal packages to support this new version.

Laravel 11 no longer supports PHP 8.1 and therefore I've created a "1.x" and "2.x" branch so that we can continue to maintain both packages for bug fixes. Going forward new features should only be added to v2 of the package.